### PR TITLE
Remove magit git executable overriding

### DIFF
--- a/emacs/.spacemacs.d/init.el
+++ b/emacs/.spacemacs.d/init.el
@@ -890,13 +890,6 @@ before packages are loaded."
              ("f" . ocamlformat)
              ("v" . merlin-enclosing-expand))
 
-  (with-eval-after-load 'magit
-    (defvar magit-git-executable)
-    ;; Hack to force usage of native ARM git executable on macOS, which is much
-    ;; faster than the x86 version from nixpkgs.
-    (when (eq system-type 'darwin)
-      (setq magit-git-executable "/usr/bin/git")))
-
   (with-eval-after-load 'pocket-reader
     (defvar pocket-reader-mode-map)
     (bind-key "b" 'bcc32/pocket-reader-browse pocket-reader-mode-map))


### PR DESCRIPTION
```console
λ git --version  --build-options
git version 2.44.1
cpu: arm64
no commit associated with this build
sizeof-long: 8
sizeof-size_t: 8
shell-path: /nix/store/1g5b7swjaw1j5wd6ljk8zvx8l37hjbm9-bash-5.2p26/bin/bash
feature: fsmonitor--daemon

~
λ /usr/bin/git --version --build-options
git version 2.39.3 (Apple Git-146)
cpu: arm64
no commit associated with this build
sizeof-long: 8
sizeof-size_t: 8
shell-path: /bin/sh
feature: fsmonitor--daemon
```

Now `git` package from `Nixpkgs` is arm64.